### PR TITLE
simbricks/pci.cc: fix memory leak due to adoption of SimBricks posted PCIe writes

### DIFF
--- a/src/simbricks/pci.cc
+++ b/src/simbricks/pci.cc
@@ -252,9 +252,13 @@ Device::writeAsync(PciPioCompl &comp)
     write->bar = bar;
     memcpy((void *)write->data, comp.pkt->getPtr<uint8_t>(),
             comp.pkt->getSize());
-    adapter.outSend(h2d_msg, writesPosted
-                                 ? SIMBRICKS_PROTO_PCIE_H2D_MSG_WRITE_POSTED
-                                 : SIMBRICKS_PROTO_PCIE_H2D_MSG_WRITE);
+    
+    if (writesPosted) {
+        comp.setDone();
+        adapter.outSend(h2d_msg, SIMBRICKS_PROTO_PCIE_H2D_MSG_WRITE_POSTED);
+    } else {
+        adapter.outSend(h2d_msg, SIMBRICKS_PROTO_PCIE_H2D_MSG_WRITE);
+    }
 }
 
 Tick


### PR DESCRIPTION
memory leak was introduced in P8d3a7b8c7869d11d1fcead9e8ac4b1e906ad2a2e