### PR TITLE
configs: remove dependence on perf events for kvm

### DIFF
--- a/configs/simbricks/simbricks.py
+++ b/configs/simbricks/simbricks.py
@@ -474,6 +474,9 @@ def build_system(np):
         FutureClass
     ):
         sys.kvm_vm = KvmVM()
+        # disable relying on performance counters for kvm cpu
+        for cpu in sys.cpu:
+            cpu.usePerf = False
 
     CacheConfig.config_cache(args, sys)
     # if args.caches and args.l3cache and args.ddio_enabled:


### PR DESCRIPTION
Sets usePerf to false for KVM CPUs. With this we can run on systems without access to performance counters.